### PR TITLE
18주차 문제풀이 - Queue-ri

### DIFF
--- a/week18/1941/Queue-ri.java
+++ b/week18/1941/Queue-ri.java
@@ -1,0 +1,92 @@
+import java.io.*;
+import java.util.*;
+
+public class Main
+{
+    static int[][] table = new int[5][5];
+    static boolean[] visited = new boolean[25];
+    static int[] selected = new int[7];
+    static int[] dy = {-1, 0, 0, 1};
+    static int[] dx = {0, -1, 1, 0};
+    
+    public static int dfs(int idx, int depth) {
+        if (depth == 7) return bfs() ? 1 : 0;
+        
+        int res = 0;
+        for (int i = idx+1; i < 25; ++i) {
+            if (!visited[i]) {
+                visited[i] = true;
+                selected[depth] = i;
+                res += dfs(i, depth+1);
+                selected[depth] = -1;
+                visited[i] = false;
+            }
+        }
+        
+        return res;
+    }
+    
+    public static boolean bfs() {
+        Deque<int[]> q = new ArrayDeque<>();
+        boolean[] joined = new boolean[7]; // visited for 'selected'
+        
+        int yimCnt = 0;
+        int somCnt = 0;
+        
+        int y = selected[0] / 5;
+        int x = selected[0] % 5;
+        q.add(new int[]{y, x});
+        joined[0] = true;
+        if (table[y][x] == 0) ++yimCnt; else ++somCnt;
+        
+        while (!q.isEmpty()) {
+            int[] pos = q.pop();
+            for (int d = 0; d < 4; ++d) {
+                int ny = pos[0] + dy[d];
+                int nx = pos[1] + dx[d];
+                
+                if (ny < 0 || 4 < ny || nx < 0 || 4 < nx) continue; // out of bound
+                
+                int sdx = 0; // find index of adj value in selected: 0으로 두면 어차피 밑에서 continue 처리됨
+                for (int s = 0; s < 7; ++s)
+                    if (selected[s] == ny*5+nx) sdx = s;
+                    
+                if (joined[sdx]) continue; // target value has already joined
+                joined[sdx] = true; // else join
+                
+                q.add(new int[]{ny, nx});
+                
+                if (table[ny][nx] == 0) ++yimCnt; else ++somCnt;
+                if (3 < yimCnt) return false; // 생존 불가
+            }
+        }
+        
+        return (yimCnt + somCnt == 7) ? true : false;
+    }
+    
+	public static void main (String[] args) throws IOException {
+	    input();
+	    
+	    int ans = 0;
+	    for (int i = 0; i < 19; ++i) { // 0 ~ 25-7+1
+	        visited[i] = true;
+	        selected[0] = i;
+	        ans += dfs(i, 1);
+	        selected[0] = -1;
+	        visited[i] = false;
+	    }
+	    
+	    System.out.println(ans);
+	}
+	
+	public static void input() throws IOException {
+	    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	    
+	    for (int i = 0; i < 5; ++i) {
+	        char[] line = br.readLine().toCharArray();
+	        for (int j = 0; j < 5; ++j) {
+	            table[i][j] = line[j] == 'S' ? 1 : 0;
+	        }
+	    }
+	}
+}

--- a/week18/4179/Queue-ri.java
+++ b/week18/4179/Queue-ri.java
@@ -1,0 +1,79 @@
+import java.io.*;
+import java.util.*;
+
+public class Main
+{
+    static int r, c;
+    static int[][] miro;
+    static boolean[][] fvisited;
+    static boolean[][] jvisited;
+    static Deque<int[]> fq = new ArrayDeque<>();
+    static Deque<int[]> jq = new ArrayDeque<>();
+    static int[] dy = {-1, 0, 0, 1};
+    static int[] dx = {0, -1, 1, 0};
+    
+    public static int bfs() {
+        // queue init was done in input()
+        int time = 1;
+        
+		while (!jq.isEmpty()) { // until J evacuate
+	        while (!fq.isEmpty() && fq.peek()[2] == time) {
+    		    int[] fpos = fq.pop();
+    		    for (int d = 0; d < 4; ++d) {
+    		        int nfy = fpos[0] + dy[d];
+    		        int nfx = fpos[1] + dx[d];
+    		        if (nfy < 0 || r <= nfy || nfx < 0 || c <= nfx) continue; // out of bound
+    		        if (fvisited[nfy][nfx] || miro[nfy][nfx] == 1) continue;
+    		        fvisited[nfy][nfx] = true;
+    		        fq.add(new int[]{nfy, nfx, time+1});
+    		    }
+	        }
+		    
+		    while (!jq.isEmpty() && jq.peek()[2] == time) {
+    		    int[] jpos = jq.pop();
+    		    for (int d = 0; d < 4; ++d) {
+    		        int njy = jpos[0] + dy[d];
+    		        int njx = jpos[1] + dx[d];
+    		        if (njy < 0 || r <= njy || njx < 0 || c <= njx) return time; // evacuate
+    		        if (fvisited[njy][njx] || jvisited[njy][njx] || miro[njy][njx] == 1) continue;
+    		        jvisited[njy][njx] = true;
+    		        jq.add(new int[]{njy, njx, time+1});
+    		    }
+		    }
+		    ++time;
+		}
+		
+		return -1;
+    }
+    
+	public static void main(String[] args) throws IOException {
+		input();
+		int ans = bfs();
+		System.out.println(ans == -1 ? "IMPOSSIBLE" : ans);
+	}
+	
+	public static void input() throws IOException {
+	    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	    StringTokenizer st = new StringTokenizer(br.readLine());
+	    r = Integer.parseInt(st.nextToken());
+	    c = Integer.parseInt(st.nextToken());
+	    miro = new int[r][c];
+	    fvisited = new boolean[r][c];
+	    jvisited = new boolean[r][c];
+	    
+	    for (int i = 0; i < r; ++i) {
+	        char[] line = br.readLine().toCharArray();
+	        for (int j = 0; j < c; ++j) {
+	            miro[i][j] = line[j] == '#' ? 1 : 0;
+	            if (line[j] == 'J') {
+                    jq.add(new int[]{i, j, 1});
+                    jvisited[i][j] = true;
+	            }
+	            else if (line[j] == 'F') {
+	                fq.add(new int[]{i, j, 1});
+	                fvisited[i][j] = true;
+	            }
+	        }
+	    }
+	}
+}

--- a/week18/60059/Queue-ri.java
+++ b/week18/60059/Queue-ri.java
@@ -1,0 +1,75 @@
+class Solution {
+    int n, m;
+    int zeros; // number of zeros in lock
+    int[][] key, lock;
+    int[][] key90, key180, key270;
+    int[][][] keyArr;
+
+    public boolean solution(int[][] key, int[][] lock) {
+        this.n = lock.length;
+        this.m = key.length;
+        this.key = key;
+        this.lock = lock;
+        initKey();
+        initZeros();
+
+        // set offset
+        for (int yOfs = -m + 1; yOfs < n; ++yOfs) {
+            for (int xOfs = -m + 1; xOfs < n; ++xOfs) {
+                boolean[] kFail = new boolean[4];
+                int[] cnt = new int[4];
+
+                kfor: // offset done -> match key
+                for (int k = 0; k < 4; ++k) {
+                    for (int ky = 0; ky < m; ++ky) {
+                        for (int kx = 0; kx < m; ++kx) {
+                            if (kFail[k]) continue;
+
+                            int ly = ky + yOfs;
+                            int lx = kx + xOfs;
+                            if (ly < 0 || ly >= n || lx < 0 || lx >= n) continue;
+
+                            int kVal = keyArr[k][ky][kx];
+                            int lVal = lock[ly][lx];
+
+                            if ((kVal ^ lVal) == 0) { // collide or can't solve all
+                                kFail[k] = true;
+                                continue kfor;
+                            } else if (lVal == 0) { // match: 1 solved
+                                ++cnt[k];
+                            }
+                        }
+                    }
+                } // end of key match
+
+                for (int i = 0; i < cnt.length; ++i) {
+                    if (cnt[i] == zeros && !kFail[i]) return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public void initKey() {
+        key90 = new int[m][m];
+        key180 = new int[m][m];
+        key270 = new int[m][m];
+        keyArr = new int[][][]{key, key90, key180, key270};
+        for (int i = 0; i < m; ++i) {
+            for (int j = 0; j < m; ++j) {
+                key90[j][m - i - 1] = key[i][j];
+                key180[m - i - 1][m - j - 1] = key[i][j];
+                key270[m - j - 1][i] = key[i][j];
+            }
+        }
+    }
+
+    public void initZeros() {
+        for (int i = 0; i < n; ++i) {
+            for (int j = 0; j < n; ++j) {
+                if (lock[i][j] == 0) ++zeros;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### 소문난 칠공주
- 조합, dfs, bfs
- dfs의 단말에서 bfs를 수행하여 dfs로 선택한 구성이 칠공주 조건에 맞는지 검사

#### 자물쇠와 열쇠
- 빡구현
- 배열 확장 대신 오프셋 조정 방식으로 수행시간 최적화

#### 불!
- 더블 bfs
- 불과 지훈이가 같은 곳에 동시 도착시 지훈이가 타버림
    - 불 bfs를 먼저 수행해서 visited 체크하고, 지훈 bfs에서 애초에 그 칸을 진행하지 않는 것으로 처리
- 경계 좌표에 있을때 탈출하지 않고 bound check에서 탈출 처리
    - 지훈이가 처음부터 경계에 있을 때의 별도 처리 로직이 필요없어짐 -> 코드 깔끔~
    - 아마 수행시간에 영향 있을 것. 차이 좀 나면 수정하겠습니다.